### PR TITLE
fix syll_prefix bug

### DIFF
--- a/IS_Java_Version/src/main/java/app/controller/Sylladex.java
+++ b/IS_Java_Version/src/main/java/app/controller/Sylladex.java
@@ -316,7 +316,7 @@ public class Sylladex {
         if (rawInputString.isEmpty()) return;
 
         //determine where to send input based on prefix. no prefix means its for modus.
-        if (rawInputString.toUpperCase().startsWith(SYLL_PREFIX)) {
+        if (rawInputString.toUpperCase().startsWith(SYLL_PREFIX.toUpperCase())) {
             handleSyllInput(rawInputString.substring(SYLL_PREFIX.length()));
         } else {
             if (wrappedModusInput.getAndSet(rawInputString) != null)


### PR DESCRIPTION
fixes syll_prefix bug by making the comparison force both input and target to the same case. prefix can now match input as case-insensitive.